### PR TITLE
Dereference the value in case pointer is passed for With

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -3,6 +3,7 @@ package clog
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/alcionai/clues"
 	"go.uber.org/zap"
@@ -129,6 +130,20 @@ func (b *builder) Comment(cmnt string) *builder {
 	return b
 }
 
+// getValue will return the value if not pointer, or the dereferenced
+// value if it is a pointer.
+func getValue(v any) any {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil
+		}
+
+		return rv.Elem().Interface()
+	}
+	return v
+}
+
 // With is your standard "With" func.  Add data in K:V pairs here to have them
 // added to the log message metadata.  Ex: builder.With("foo", "bar") will add
 // "foo": "bar" to the resulting log structure.  An uneven number of pairs will
@@ -146,7 +161,7 @@ func (b *builder) With(vs ...any) *builder {
 			v = vs[i+1]
 		}
 
-		b.with[k] = v
+		b.with[k] = getValue(v)
 	}
 
 	return b

--- a/builder_test.go
+++ b/builder_test.go
@@ -93,3 +93,48 @@ func (suite *BuilderUnitSuite) testErrorLogs(bld *builder) {
 	bld.Errorw("a log", "with key")
 	bld.Errorw("a log", "with key", "and value")
 }
+
+func (suite *BuilderUnitSuite) TestGetValue() {
+	table := []struct {
+		name     string
+		value    any
+		expected any
+	}{
+		{
+			name:     "integer",
+			value:    1,
+			expected: 1,
+		},
+		{
+			name:     "string",
+			value:    "foo",
+			expected: "foo",
+		},
+		{
+			name: "pointer to string",
+			value: func() *string {
+				s := "foo"
+				return &s
+			}(),
+			expected: "foo",
+		},
+		{
+			name:     "nil",
+			value:    nil,
+			expected: nil,
+		},
+		{
+			name: "nil pointer",
+			value: func() *string {
+				return nil
+			}(),
+			expected: nil,
+		},
+	}
+
+	for _, tt := range table {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getValue(tt.value))
+		})
+	}
+}


### PR DESCRIPTION
I've seen a bunch of cases where uses would accidentally pass in pointers instead of the value. This would be a fix for those accidents.

@ryanfkeepers I'll let you decide if this is a good change, but thought I would create a PR as it was easy enough.